### PR TITLE
Fix Tray Icon not Displaying

### DIFF
--- a/com.notesnook.Notesnook.yml
+++ b/com.notesnook.Notesnook.yml
@@ -88,4 +88,5 @@ modules:
       - type: script
         dest-filename: start-notesnook.sh
         commands:
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
           - zypak-wrapper.sh /app/bin/notesnook --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations "$@"


### PR DESCRIPTION
This fixes the tray icon by exporting the `TMPDIR` correctly, so the handlers for these things know where to check for the icon related to this Electron app. Check these commits in the [Discord Flatpak](https://github.com/flathub/com.discordapp.Discord/commit/90d9f1a0c350b4d479738476e53fea4bba473a83) or the [Vencord Flatpak](https://github.com/flathub/dev.vencord.Vesktop/pull/10/files) for more info. This fixes it, at least on [GNOME](https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/471) and maybe other desktops.

closes #51 and https://github.com/streetwriters/notesnook/issues/2035