### PR TITLE
Use Fallback X11 Socket

### DIFF
--- a/com.notesnook.Notesnook.yml
+++ b/com.notesnook.Notesnook.yml
@@ -13,7 +13,7 @@ finish-args:
   # Wayland access
   - --socket=wayland
   # X11 fallback socket
-  - --socket=x11-fallback
+  - --socket=fallback-x11
   # audio
   - --socket=pulseaudio
   # required for Electron hardware acceleration

--- a/com.notesnook.Notesnook.yml
+++ b/com.notesnook.Notesnook.yml
@@ -10,10 +10,10 @@ command: start-notesnook
 separate-locales: false
 finish-args:
   - --share=ipc
-  # X11 access
-  - --socket=x11
   # Wayland access
   - --socket=wayland
+  # X11 fallback socket
+  - --socket=x11-fallback
   # audio
   - --socket=pulseaudio
   # required for Electron hardware acceleration


### PR DESCRIPTION
This uses the `x11-fallback` socket instead of the `x11` socket, since that is the intended configuration for apps that work natively on Wayland, which this Flatpak is correctly configured to do ([reference](https://docs.flatpak.org/en/latest/sandbox-permissions.html)).

> Applications that do not support native Wayland should use only --socket=x11 and applications that do, should use --socket=fallback-x11 and --socket=wayland. The two configurations here will make the application work on both X11 and Wayland sessions of the desktop environment.