### PR TITLE
Bump Runtimes to 24.08

### DIFF
--- a/com.notesnook.Notesnook.yml
+++ b/com.notesnook.Notesnook.yml
@@ -1,9 +1,9 @@
 app-id: com.notesnook.Notesnook
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 command: start-notesnook


### PR DESCRIPTION
This bumps the runtimes to their latest version. Not much more to say about this, but it being mainly maintenance work. Tested these changes locally and it works as intended.